### PR TITLE
Fixed typo in 'sdl-get-texture-color-mod'

### DIFF
--- a/src/ffi/render.lisp
+++ b/src/ffi/render.lisp
@@ -100,7 +100,7 @@
   (g :uint8)
   (b :uint8))
 
-(defsdl2fun ("SDL_GetTextureColorMod" sdl-gettexture-color-mod) :int
+(defsdl2fun ("SDL_GetTextureColorMod" sdl-get-texture-color-mod) :int
   (texture (:pointer sdl-texture))
   (r (:pointer :uint8))
   (g (:pointer :uint8))


### PR DESCRIPTION
Not much to say, but i wonder if it would be sensible to define an alias of the old definition in case people already depend on the typo instead of fixing it.